### PR TITLE
Fix for empty array checking

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -1800,6 +1800,7 @@ var TAFFY, exports, T;
               });
             }
             else if ( T.isString( var2 ) || T.isNumber( var2 ) ){
+              re = false;
               for ( n = 0; n < var1.length; n++ ){
                 re = T.has( var1[n], var2 );
                 if ( re ){


### PR DESCRIPTION
When using 'has' to search for strings in an array, it will currently match records with empty arrays. This patch fixes this issue.
