### PR TITLE
Caching bug fix

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -33,7 +33,9 @@ var TAFFY, exports, T;
     version,      TC,           idpad,  cmax,
     API,          protectJSON,  each,   eachin,
     isIndexable,  returnFilter, runFilters,
-    numcharsplit, orderByCol,   run
+    numcharsplit, orderByCol,   run,    intersection,
+    filter,       makeCid,      safeForJson, 
+    isRegexp
     ;
 
 
@@ -62,6 +64,43 @@ var TAFFY, exports, T;
       }
     };
 
+    // gracefully stolen from underscore.js
+    intersection = function(array1, array2) {
+        return filter(array1, function(item) {
+          return array2.indexOf(item) >= 0;
+        });
+    };
+
+    // gracefully stolen from underscore.js
+    filter = function(obj, iterator, context) {
+        var results = [];
+        if (obj == null) return results;
+        if (Array.prototype.filter && obj.filter === Array.prototype.filter) return obj.filter(iterator, context);
+        each(obj, function(value, index, list) {
+          if (iterator.call(context, value, index, list)) results[results.length] = value;
+        });
+        return results;
+    };
+    
+    isRegexp = function(aObj) {
+        return Object.prototype.toString.call(aObj)==='[object RegExp]';
+    }
+    
+    safeForJson = function(aObj) {
+        var myResult = T.isArray(aObj) ? [] : T.isObject(aObj) ? {} : null;
+        if(aObj===null) return aObj;
+        for(var i in aObj) {
+            myResult[i]  = isRegexp(aObj[i]) ? aObj[i].toString() : T.isArray(aObj[i]) || T.isObject(aObj[i]) ? safeForJson(aObj[i]) : aObj[i];
+        }
+        return myResult;
+    }
+    
+    makeCid = function(aContext) {
+        var myCid = JSON.stringify(aContext);
+        if(myCid.match(/regex/)===null) return myCid;
+        return JSON.stringify(safeForJson(aContext));
+    }
+    
     each = function ( a, fun, u ) {
       var r, i, x, y;
       // ****************************************
@@ -1403,7 +1442,7 @@ var TAFFY, exports, T;
               }
             });
             if ( cid === '' ){
-              cid = JSON.stringify( T.mergeObj( context,
+              cid = makeCid( T.mergeObj( context,
                 {q : false, run : false, sort : false} ) );
             }
           }


### PR DESCRIPTION
Hi 'Joe',

I've made a few changes. One was to had a 'contains' comparator for fields containing arrays, e.g.:

{
name: 'James'
types: ['x','y','z']
}

then compared with 

taffyDB({types:{contains:'y'}})

The other thing is a broken caching key with regex:

taffyDB({name:{regex:/James/}}).count() === 1;
taffyDB({name:{regex:/Anything else at this point/}}).count() === 1;
taffyDB({name:{regex:/Will always work/}}).count() === 1;

Because: 
JSON.stringify(/Anything/) === JSON.stringify(/Everything/) && 
JSON.stringify(/Everything/) === '{}'
