### PR TITLE
Prevents throwing errors on mobile safari

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -1278,8 +1278,7 @@ var TAFFY, exports, T;
           }
           if ( settings.storageName ){
             setTimeout( function () {
-              localStorage.setItem( 'taffy_' + settings.storageName,
-                JSON.stringify( TOb ) );
+              try { localStorage.setItem( 'taffy_' + settings.storageName, JSON.stringify( TOb ) ); } catch(Exception) {}
             });
           }
           return dm;


### PR DESCRIPTION
On mobile safari with larger datasets this lines throws error:
QUOTA_EXCEEDED_ERR: DOM Exception 22: An attempt was made to add something to storage that exceeded the quota
