### PR TITLE
Prevents throwing errors on mobile safari

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -1695,8 +1695,11 @@ var TAFFY, exports, T;
             }
             if ( TOb.length > 0 ){
               setTimeout( function () {
-                localStorage.setItem( 'taffy_' + settings.storageName,
-                  JSON.stringify( TOb ) );
+               try {
+                localStorage.setItem( 'taffy_' + settings.storageName, JSON.stringify( TOb ) );
+               } (Exception) {
+                
+               }
               });
             }
           }


### PR DESCRIPTION
Second place that throws QUOTA_EXCEEDED_ERR: DOM Exception 22
