### PR TITLE
issue #46 - added the appropriate bower.json necessary for registering with bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,25 @@
+{
+  "name": "taffydb",
+  "version": "2.7.2",
+  "homepage": "http://taffydb.com/",
+  "authors": [
+    "Ian Smith",
+    "Todd Chambery <todd.chambery@gmail.com>",
+    "Daniel Ruf <kontakt@daniel-ruf.de>",
+    "Michael Mikowski <mmikowski@snaplogic.com>",
+    "Matthew Chase Whittemore <mcwhittemore@gmail.com>"
+  ],
+  "description": "TaffyDB is an opensource library that brings database features into your JavaScript applications.",
+  "main": "taffy.js",
+  "keywords": [
+    "database"
+  ],
+  "license": "BSD",
+  "ignore": [
+    "**/.*",
+    "node_modules",
+    "bower_components",
+    "test",
+    "tests"
+  ]
+}


### PR DESCRIPTION
- the bower.json was based entirely on the package.json and the README mentioning that this was a BSD license project
- a repository committer can reference: http://bower.io/#registering-packages
- a tag matching the appropriate version number (2.7.2 as of this pull request) would need to be added an pushed to github when registering
