### PR TITLE
Added array and object comparisons on update

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -1384,6 +1384,18 @@ var TAFFY, exports, T;
             if ( TAFFY.isUndefined( or[i] ) || or[i] !== v ){
               tc[i] = v;
               hasChange = true;
+            }else if ( T.isArray(or[i] ) ){
+              //compare array
+              if(T.isSameArray(or[i], v)){
+                tc[i] = v;
+                hasChange = true;
+              }
+            }else if ( T.isObject(or[i] ) ){
+              //compare object
+              if(T.isSameObject(or[i], v)){
+                tc[i] = v;
+                hasChange = true;
+              }
             }
           });
           if ( hasChange ){


### PR DESCRIPTION
This pull fixes issue #85 by forcing the update function to compare database values as arrays and objects if applicable. 
