### PR TITLE
prevent exception when using leftnocase,,likenocase etc

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -320,7 +320,7 @@ var TAFFY, exports, T;
                   r
                   ;
 
-                if (typeof mvalue === 'undefined') {
+                if ((typeof mvalue === 'undefined') || (mvalue === null)) {
                   return false;
                 }
                 


### PR DESCRIPTION
Fixes following issue:
// Note: last city added has null value for name
var cities = TAFFY([{name:"New York",state:"WA"},{name:"Las Vegas",state:"NV"},{name:null,state:"MA"}]);

// Query for cities whose name starts with N or n
cities({name:{leftnocase:'n'}}).get();

TypeError: Cannot read property 'toLowerCase' of null
