### PR TITLE
Added "license" field to package.json.

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "email": "mcwhittemore@gmail.com"
     }
   ],
+  "license": "BSD-2-Clause",
   "name": "taffydb",
   "main": "./taffy",
   "description": "TaffyDB is an opensouce library that brings database features into your JavaScript applications.",


### PR DESCRIPTION
Adding a "license" field to package.json. This fixes #107. The license for this project appears to be a 2-Clause BSD license, so that's what I selected. If another license from [this list](https://spdx.org/licenses/) makes more sense, please let me know!