### PR TITLE
Break circular dependencies

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -35,7 +35,7 @@ var TAFFY, exports, T;
     isIndexable,  returnFilter, runFilters,
     numcharsplit, orderByCol,   run,    intersection,
     filter,       makeCid,      safeForJson,
-    isRegexp, sortArgs
+    isRegexp, sortArgs, safeForJsonRecursive
     ;
     
     
@@ -90,12 +90,22 @@ var TAFFY, exports, T;
     isRegexp = function(aObj) {
         return Object.prototype.toString.call(aObj)==='[object RegExp]';
     }
-    
+
     safeForJson = function(aObj) {
+        return safeForJsonRecursive(aObj, []);
+    }
+
+    safeForJsonRecursive = function(aObj, aPrevious) {
+        for (var i in aPrevious) {
+          if (aPrevious[i]===aObj) {
+            return null;
+          }
+        }
+        aPrevious.push(aObj);
         var myResult = T.isArray(aObj) ? [] : T.isObject(aObj) ? {} : null;
         if(aObj===null) return aObj;
         for(var i in aObj) {
-            myResult[i]  = isRegexp(aObj[i]) ? aObj[i].toString() : T.isArray(aObj[i]) || T.isObject(aObj[i]) ? safeForJson(aObj[i]) : aObj[i];
+            myResult[i]  = isRegexp(aObj[i]) ? aObj[i].toString() : T.isArray(aObj[i]) || T.isObject(aObj[i]) ? safeForJsonRecursive(aObj[i], aPrevious) : aObj[i];
         }
         return myResult;
     }


### PR DESCRIPTION
Background:

- During some development using Babel, ES6 and running tasks such as Gitbook - it became apparent that someone was loading modifications to object prototypes that would introduce properties on global prototypes that would cause circular dependencies.
- Seemingly any time a circular object comes through the safeJson function, it breaks.

Confident this represents a least-harm way to get things sorted - Objects with this issue _are not_ capable of going through TaffyDB at the moment, so this can't cause a change in behaviour unless someone is relying expressly on a node-crashing stack overflow issue.