### PR TITLE
Add default export

### DIFF
--- a/taffy.js
+++ b/taffy.js
@@ -2019,3 +2019,7 @@ var TAFFY, exports, T;
 if ( typeof(exports) === 'object' ){
   exports.taffy = TAFFY;
 }
+
+if (module) {
+  module.exports = TAFFY;
+}


### PR DESCRIPTION
The export is not working for me.

Now you can use TaffyDB like this:

```
import taffy from "taffydb";
```